### PR TITLE
Updated woodpecker.yml and stremio-stack.yml

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,8 +2,10 @@ steps:
   build-mammamia:
     image: woodpeckerci/plugin-docker-buildx:6.0.1
     settings:
-      dockerfile: ./mammamia/Dockerfile
-      context: ./mammamia
+      #dockerfile: ./mammamia/Dockerfile
+      #context: ./mammamia
+      context: https://github.com/UrloMythus/MammaMia.git#main
+      dockerfile: Dockerfile
       repo: registry.oci.w3studio.it/mammamia
       tags: latest, ${CI_COMMIT_SHA}
       push: true
@@ -16,7 +18,7 @@ steps:
     image: woodpeckerci/plugin-docker-buildx:6.0.1
     settings:
       dockerfile: Dockerfile
-      context: https://github.com/nzo66/mediaflow-proxy.git#main
+      context: https://github.com/mhdzumair/mediaflow-proxy.git#main
       repo: registry.oci.w3studio.it/media_flow_proxy
       tags: latest, ${CI_COMMIT_SHA}
       push: true
@@ -28,7 +30,7 @@ steps:
   build-streamv:
     image: woodpeckerci/plugin-docker-buildx:6.0.1
     settings:
-      context: "https://github.com/qwertyuiop8899/streamvix.git#main"
+      context: https://github.com/qwertyuiop8899/streamvix.git#main
       dockerfile: Dockerfile
       repo: registry.oci.w3studio.it/streamv
       tags: latest, ${CI_COMMIT_SHA}
@@ -63,9 +65,9 @@ steps:
       - /var/run/docker.sock:/var/run/docker.sock
     commands:
       - echo "$OCI_REGISTRY_PASSWORD" | docker login registry.oci.w3studio.it -u "$OCI_REGISTRY_USER" --password-stdin
-      - docker service update --image registry.oci.w3studio.it/mammamia:${CI_COMMIT_SHA} --with-registry-auth stremio_mammamia
-      - docker service update --image registry.oci.w3studio.it/media_flow_proxy:${CI_COMMIT_SHA} --with-registry-auth stremio_mediaflow_proxy
-      - docker service update --image registry.oci.w3studio.it/streamv:${CI_COMMIT_SHA} --with-registry-auth stremio_streamv
+      - docker service update --image registry.oci.w3studio.it/mammamia:${CI_COMMIT_SHA} --with-registry-auth stremio-stack_mammamia
+      - docker service update --image registry.oci.w3studio.it/media_flow_proxy:${CI_COMMIT_SHA} --with-registry-auth stremio-stack_mediaflow_proxy
+      - docker service update --image registry.oci.w3studio.it/streamv:${CI_COMMIT_SHA} --with-registry-auth stremio-stack_streamv
     #  - docker service update --image registry.oci.w3studio.it/webstreamr:${CI_COMMIT_SHA} --with-registry-auth stremio_webstreamr
       
       

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -1,6 +1,3 @@
-when:
-  - event: push
-    branch: main
 steps:
   build-mammamia:
     image: woodpeckerci/plugin-docker-buildx:6.0.1

--- a/streamv/Dockerfile
+++ b/streamv/Dockerfile
@@ -1,4 +1,3 @@
-# Scegli un'immagine Node.js di base
 FROM node:20-slim
 
 ARG CACHE_BUST=233
@@ -86,4 +85,5 @@ ENTRYPOINT ["node", "/start"]
 # EXPOSE 3000 
 
 # Definisci il comando per avviare l'applicazione
+
 #CMD [ "pnpm", "start" ]

--- a/stremio-stack.yml
+++ b/stremio-stack.yml
@@ -13,7 +13,7 @@ services:
         - "traefik.enable=true"
         - "traefik.http.routers.media_proxy.rule=Host(`mfp.oci.w3studio.it`)"
         - "traefik.http.routers.media_proxy.entrypoints=websecure"
-        - "traefik.http.routers.media_proxy.tls.certresolver=ovh"
+        - "traefik.http.routers.media_proxy.tls.certresolver=letsencrypt"
         - "traefik.http.services.media_proxy.loadbalancer.server.port=8888"
     networks:
       - traefik-net
@@ -29,7 +29,7 @@ services:
         - "traefik.enable=true"
         - "traefik.http.routers.mammamia.rule=Host(`mammamia.oci.w3studio.it`)"
         - "traefik.http.routers.mammamia.entrypoints=websecure"
-        - "traefik.http.routers.mammamia.tls.certresolver=ovh"
+        - "traefik.http.routers.mammamia.tls.certresolver=letsencrypt"
         - "traefik.http.services.mammamia.loadbalancer.server.port=8080"
     networks:
       - traefik-net
@@ -51,7 +51,7 @@ services:
         - "traefik.enable=true"
         - "traefik.http.routers.streamv.rule=Host(`streamv.oci.w3studio.it`)"
         - "traefik.http.routers.streamv.entrypoints=websecure"
-        - "traefik.http.routers.streamv.tls.certresolver=ovh"
+        - "traefik.http.routers.streamv.tls.certresolver=letsencrypt"
         - "traefik.http.services.streamv.loadbalancer.server.port=7860"
   #webstreamr:
   #  image: registry.oci.w3studio.it/webstreamr:latest


### PR DESCRIPTION
This pull request updates deployment and configuration files to improve Docker build processes and update service routing for the stack. The most significant changes include switching Docker build contexts to use remote repositories, updating service names for Docker updates, and standardizing TLS certificate resolvers across services.

**Docker build and deployment improvements:**

* Updated the Docker build context for `mammamia` in `.woodpecker.yml` to use a remote GitHub repository instead of local paths, streamlining CI builds.
* Changed the Docker build context for `mediaflow-proxy` to point to a new repository owner, ensuring the correct source is used for builds.
* Modified the Docker service update commands to use the new `stremio-stack_*` service names, aligning deployment with the current stack configuration.

**Configuration standardization:**

* Updated the TLS certificate resolver from `ovh` to `letsencrypt` for all services in `stremio-stack.yml`, unifying certificate management and improving compatibility. [[1]](diffhunk://#diff-bdb64dea038cf68e3bd0c189a09cdefa19b6610940fcae5e5844038e113f7e96L16-R16) [[2]](diffhunk://#diff-bdb64dea038cf68e3bd0c189a09cdefa19b6610940fcae5e5844038e113f7e96L32-R32) [[3]](diffhunk://#diff-bdb64dea038cf68e3bd0c189a09cdefa19b6610940fcae5e5844038e113f7e96L54-R54)

**Minor Dockerfile cleanup:**

* Removed a commented line in `streamv/Dockerfile` for clarity and left the entrypoint unchanged. [[1]](diffhunk://#diff-76fc81e73deea3717eca4073540c1d469519d2a829543077b72996c46f4671d5L1) [[2]](diffhunk://#diff-76fc81e73deea3717eca4073540c1d469519d2a829543077b72996c46f4671d5R88)